### PR TITLE
Create Dummy OSR USB Device COM Interface

### DIFF
--- a/OsrUsbApi/OsrUsbApiDll.idl
+++ b/OsrUsbApi/OsrUsbApiDll.idl
@@ -35,6 +35,24 @@ import "unknwn.idl";
 
 
 // ---------------------------------------------------------------------------
+// IOsrUsbDevice
+//
+// Represents a particular OSR USB device and provides class-wide methods for
+// interaction and manipulation.
+//
+[
+    object,
+    local,
+    uuid(AE962B52-070A-4A1A-8D50-7C9B12920324),
+    nonextensible,
+    helpstring("OsrUsbDevice Interface"),
+    pointer_default(unique)
+]
+interface IOsrUsbDevice : IUnknown
+{
+};
+
+// ---------------------------------------------------------------------------
 // IOsrUsbDeviceEnumerator
 //
 // Provides methods for enumerating IOsrUsbDevice objects.

--- a/OsrUsbApi/OsrUsbApiDll.idl
+++ b/OsrUsbApi/OsrUsbApiDll.idl
@@ -138,7 +138,7 @@ interface IOsrUsbDeviceEnumerator : IUnknown
     //                              successful EnumerateDevices call.
     //
     [id(3), helpstring("method GetDeviceByIndex")]
-    HRESULT GetDeviceByIndex([in, annotation("__in")] DWORD dwDeviceId, [out, annotation("__out")] void** ppDevice);
+    HRESULT GetDeviceByIndex([in, annotation("__in")] DWORD dwDeviceId, [out, annotation("__out")] IOsrUsbDevice** ppDevice);
 };
 
 // ---------------------------------------------------------------------

--- a/OsrUsbApi/OsrUsbDeviceEnumerator.cpp
+++ b/OsrUsbApi/OsrUsbDeviceEnumerator.cpp
@@ -144,7 +144,7 @@ __useHeader STDMETHODIMP CUsbDeviceEnumerator::GetDeviceCount(DWORD* pdwDeviceCo
 //                              successful EnumerateDevices call.
 //
 //----------------------------------------------------------------------------
-__useHeader STDMETHODIMP CUsbDeviceEnumerator::GetDeviceByIndex(DWORD dwDeviceId, void** ppDevice)
+__useHeader STDMETHODIMP CUsbDeviceEnumerator::GetDeviceByIndex(DWORD dwDeviceId, IOsrUsbDevice** ppDevice)
 {
     HRESULT hr = E_NOTIMPL;
 

--- a/OsrUsbApi/OsrUsbDeviceEnumerator.h
+++ b/OsrUsbApi/OsrUsbDeviceEnumerator.h
@@ -60,7 +60,7 @@ END_COM_MAP()
 public:
     IFACEMETHOD(EnumerateDevices)();
     IFACEMETHOD(GetDeviceCount)(__out DWORD* pdwDeviceCount);
-    IFACEMETHOD(GetDeviceByIndex)(__in DWORD dwDeviceId, __out void** ppDevice);
+    IFACEMETHOD(GetDeviceByIndex)(__in DWORD dwDeviceId, __out IOsrUsbDevice** ppDevice);
 
 protected:
     ~CUsbDeviceEnumerator() throw();


### PR DESCRIPTION
- Create a dummy OSR USB device interface that represents a particular device
- Use the OSR USB device interface pointers instead of void pointers if necessary